### PR TITLE
obj_tests: Fix valgrind issues

### DIFF
--- a/src/tests/obj_tests.c
+++ b/src/tests/obj_tests.c
@@ -285,7 +285,6 @@ test_ph_svc_multiple(void **state)
     mock_ph_search(0, svcname);
     ret = ph_get_svc(&ph_ctx, svcname, &svc);
     assert_int_equal(ret, E2BIG);
-    assert_non_null(svc);
 }
 
 static void
@@ -301,7 +300,6 @@ test_ph_svc_srch_fail(void **state)
     mock_ph_search(EIO, svcname);
     ret = ph_get_svc(&ph_ctx, svcname, &svc);
     assert_int_equal(ret, EIO);
-    assert_non_null(svc);
 }
 
 
@@ -318,7 +316,6 @@ test_ph_svc_no_cn(void **state)
     mock_ph_search(0, svcname);
     ret = ph_get_svc(&ph_ctx, svcname, &svc);
     assert_int_equal(ret, EINVAL);
-    assert_non_null(svc);
 }
 
 int


### PR DESCRIPTION
The struct ph_entry will not be initialized in case of
failure in ph_get_svc.

==27977== Conditional jump or move depends on uninitialised value(s)
==27977==    at 0x5298823: _assert_true (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x4013D5: test_ph_svc_no_cn (obj_tests.c:321)
==27977==    by 0x529A658: ??? (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x529AD8E: _cmocka_run_group_tests (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x40121B: main (obj_tests.c:341)
==27977==
==27977==
==27977== 1 errors in context 2 of 3:
==27977== Conditional jump or move depends on uninitialised value(s)
==27977==    at 0x5298823: _assert_true (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x401448: test_ph_svc_srch_fail (obj_tests.c:304)
==27977==    by 0x529A658: ??? (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x529AD8E: _cmocka_run_group_tests (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x40121B: main (obj_tests.c:341)
==27977==
==27977==
==27977== 1 errors in context 3 of 3:
==27977== Conditional jump or move depends on uninitialised value(s)
==27977==    at 0x5298823: _assert_true (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x4014B5: test_ph_svc_multiple (obj_tests.c:288)
==27977==    by 0x529A658: ??? (in /usr/lib64/libcmocka.so.0.3.1)
==27977==    by 0x529AD8E: _cmocka_run_group_tests (in /usr/lib64/libcmocka.so.0.3.1)
