### PR TITLE
Don't try to free memory if asprintf fails

### DIFF
--- a/src/pam_hbac_ldap.c
+++ b/src/pam_hbac_ldap.c
@@ -279,7 +279,6 @@ compose_search_filter(struct ph_search_ctx *s,
         ret = asprintf(&filter, "(&%s(%s))", oc_filter, obj_filter);
         free(oc_filter);
         if (ret < 0) {
-            free(filter);
             return NULL;
         }
     } else {

--- a/src/pam_hbac_rules.c
+++ b/src/pam_hbac_rules.c
@@ -148,7 +148,6 @@ create_rules_filter(pam_handle_t *pamh,
                         (const char *) hostgroups->vals[i]->bv_val);
             free(prev);
             if (ret < 0) {
-                free(filter);
                 return NULL;
             }
         }
@@ -159,7 +158,6 @@ create_rules_filter(pam_handle_t *pamh,
     ret = asprintf(&filter, "%s)", prev);
     free(prev);
     if (ret < 0) {
-        free(filter);
         return NULL;
     }
 


### PR DESCRIPTION
Hello,
I don't think we should free strp if asprintf fails. In case of failure according to man page the content of strp is undefined . 
a) If it's NULL, there's no gain to free it.
b) if it's random/uninitialized value we probably get segmentation fault.
c) If value is not changed we would get double free as it is already freed in some of the calls.
d) If it points to just allocated memory we cannot distinguish that from b) and it is IMO memory leak in implementation of asprintf().

Thanks.
