### PR TITLE
Fix issue #55: Run integration tests during CI

### DIFF
--- a/ci/semaphoreci.sh
+++ b/ci/semaphoreci.sh
@@ -50,9 +50,9 @@ cd $SRC_DIR
 mkdir _build_test
 pushd _build_test
 ../configure --enable-valgrind
-make
-make check
-make check-valgrind
+make || exit 1
+make check || exit 2
+make check-valgrind || exit 3
 # Integration tests agains the public IPA demo instance
 make intgcheck VERBOSE=1 \
                IPA_HOSTNAME="ipa.demo1.freeipa.org" \
@@ -61,7 +61,7 @@ make intgcheck VERBOSE=1 \
                INSECURE_TESTS=1 \
                IPA_BASEDN="dc=demo1,dc=freeipa,dc=org" \
                BIND_DN="uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org" \
-               BIND_PW="Secret123"
+               BIND_PW="Secret123" || exit 5
 popd
 
 export CFLAGS="-g -O2 -Wall"
@@ -70,4 +70,4 @@ cd $SRC_DIR
 mkdir _build_dist
 cd _build_dist
 ../configure
-make distcheck
+make distcheck || exit 4

--- a/ci/semaphoreci.sh
+++ b/ci/semaphoreci.sh
@@ -32,6 +32,15 @@ make
 sudo make install
 popd
 
+# Build pam_wrapper..not in Ubuntu 14.04 at all
+git clone git://git.samba.org/pam_wrapper.git
+mkdir pam_wrapper/obj
+pushd pam_wrapper/obj
+cmake -DLIB_INSTALL_DIR:PATH=/usr/lib ..
+make
+sudo make install
+popd
+
 # Build pam_hbac
 export SRC_DIR=$PWD
 autoreconf -if

--- a/ci/semaphoreci.sh
+++ b/ci/semaphoreci.sh
@@ -53,6 +53,15 @@ pushd _build_test
 make
 make check
 make check-valgrind
+# Integration tests agains the public IPA demo instance
+make intgcheck VERBOSE=1 \
+               IPA_HOSTNAME="ipa.demo1.freeipa.org" \
+               IPA_DOMAIN="demo1.freeipa.org" \
+               ADMIN_PASSWORD=Secret123 \
+               INSECURE_TESTS=1 \
+               IPA_BASEDN="dc=demo1,dc=freeipa,dc=org" \
+               BIND_DN="uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org" \
+               BIND_PW="Secret123"
 popd
 
 export CFLAGS="-g -O2 -Wall"

--- a/src/intgtests/test_pam_hbac.py
+++ b/src/intgtests/test_pam_hbac.py
@@ -244,6 +244,13 @@ class IpaClientlessPamHbacRule(object):
     def disable(self):
         self.driver.run_cmd("hbacrule_disable", [self.name])
 
+    def add_all_cats(self):
+        args = dict()
+        args['usercategory'] = ['all']
+        args['hostcategory'] = ['all']
+        args['servicecategory'] = ['all']
+        self.driver.run_cmd("hbacrule_mod", [self.name], args)
+
 
 class PamHbacTestCase(unittest.TestCase):
     def setUp(self):
@@ -433,6 +440,7 @@ class PamHbacTestAllowAll(PamHbacTestCase):
 
     def test_allow_all(self):
         self.allow_all.enable()
+        self.allow_all.add_all_cats()
         self.assertAllowed("admin", "sshd")
 
     def test_allow_all_disabled(self):

--- a/src/pam_hbac.c
+++ b/src/pam_hbac.c
@@ -309,7 +309,7 @@ pam_hbac(enum pam_hbac_actions action, pam_handle_t *pamh,
     if (pam_ret != PAM_SUCCESS) {
         logger(pamh, LOG_ERR,
                "pam_hbac_get_items returned error: %s",
-               pam_strerror(pamh, ret));
+               pam_strerror(pamh, pam_ret));
         goto done;
     }
 


### PR DESCRIPTION
The attached commits use freeipa's demo server for running CI. This brings up the time to run the tests to almost 10 minutes, but I think having integration tests ran during build is worth it.

Fixes issue #55 
