### PR TITLE
Fix some pep8 warning

### DIFF
--- a/src/intgtests/test_pam_hbac.py
+++ b/src/intgtests/test_pam_hbac.py
@@ -569,7 +569,7 @@ class PamHbacTestErrorConditions(PamHbacTestCase):
         """
         self.assertPamReturns("no_such_user_ignore", "sshd", 0,
                               pam_mod_opts=["ignore_unknown_user"],
-                              additional_modules=[ { "pam_permit.so":"required"}])
+                              additional_modules=[{"pam_permit.so": "required"}])
 
     def test_root(self):
         """
@@ -578,8 +578,7 @@ class PamHbacTestErrorConditions(PamHbacTestCase):
         self.assertPamReturns("root", "sshd", 10)
         self.assertPamReturns("root", "sshd", 0,
                               pam_mod_opts=["ignore_unknown_user"],
-                              additional_modules=[ { "pam_permit.so":"required"}])
-
+                              additional_modules=[{"pam_permit.so": "required"}])
 
     def test_no_such_service(self):
         """"
@@ -603,7 +602,7 @@ class PamHbacTestErrorConditions(PamHbacTestCase):
         """
         self.assertPamReturns("admin", "sshd", 0, host="no_such_host",
                               pam_mod_opts=["ignore_authinfo_unavail"],
-                              additional_modules=[ { "pam_permit.so":"required"}])
+                              additional_modules=[{"pam_permit.so": "required"}])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hello,
I fixed some trivial pep8 warnings, however I omitted those regarding line length. I'm not sure if you prefer those lines as more readable compared to splitting them into multiple lines.
Please let me know if I should fix the remaining warnings. Thanks

Before patch:
 pep8 ./src/intgtests/test_pam_hbac.py
./src/intgtests/test_pam_hbac.py:572:51: E201 whitespace after '['
./src/intgtests/test_pam_hbac.py:572:53: E201 whitespace after '{'
./src/intgtests/test_pam_hbac.py:572:69: E231 missing whitespace after ':'
./src/intgtests/test_pam_hbac.py:572:80: E501 line too long (82 > 79 characters)
./src/intgtests/test_pam_hbac.py:581:51: E201 whitespace after '['
./src/intgtests/test_pam_hbac.py:581:53: E201 whitespace after '{'
./src/intgtests/test_pam_hbac.py:581:69: E231 missing whitespace after ':'
./src/intgtests/test_pam_hbac.py:581:80: E501 line too long (82 > 79 characters)
./src/intgtests/test_pam_hbac.py:584:5: E303 too many blank lines (2)
./src/intgtests/test_pam_hbac.py:601:80: E501 line too long (80 > 79 characters)
./src/intgtests/test_pam_hbac.py:606:51: E201 whitespace after '['
./src/intgtests/test_pam_hbac.py:606:53: E201 whitespace after '{'
./src/intgtests/test_pam_hbac.py:606:69: E231 missing whitespace after ':'
./src/intgtests/test_pam_hbac.py:606:80: E501 line too long (82 > 79 characters)

After patch:
./src/intgtests/test_pam_hbac.py:572:80: E501 line too long (81 > 79 characters)
./src/intgtests/test_pam_hbac.py:581:80: E501 line too long (81 > 79 characters)
./src/intgtests/test_pam_hbac.py:600:80: E501 line too long (80 > 79 characters)
./src/intgtests/test_pam_hbac.py:605:80: E501 line too long (81 > 79 characters)
