### PR TITLE
Port to HPUX 11.31 (ia64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pam_hbac was tested on the following operating systems and releases:
       testing was done there except integration tests.
   * FreeBSD - tested with FreeBSD 10.2
   * Solaris - tested with Solaris 11 and Omnios. Some users run pam_hbac on Solaris 10 as well.
+  * HPUX - tested with HPUX 11.31 - no SSL/TLS yet
 
 Building from source
 ====================

--- a/doc/README.HPUX
+++ b/doc/README.HPUX
@@ -1,0 +1,62 @@
+This file describes how to configure pam_hbac for access control on a
+HPUX machine.
+
+Only tested on HPUX 11.31 (ia64).
+
+Prerequisities
+==============
+Please make sure your HPUX client is able to resolve and authenticate
+the IPA or AD users. For example, for users coming from an AD trust:
+    $ id administrator@win.trust.test
+    $ su - administrator@win.trust.test
+A good starting point for this configuration is to read:
+    https://www.freeipa.org/page/ConfiguringUnixClients
+
+Building from source
+====================
+The build environment used to build the module was obtained from the HP-UX Porting
+and Archive Centre (http://hpux.connect.org.uk/).
+It is recommended to use their download and install utility 'depothelper' 
+(http://hpux.connect.org.uk/hppd/hpux/Sysadmin/depothelper-2.00/) which allows to install
+the required packages and their dependencies. On HPUX 11.31, this would be:
+    depothelper gcc autoconf libtool pkgconfig automake openldap
+
+This build environment has 32 bit libraries, the built pam module will also be 
+32 bit. HP-UX's default sshd binary is 64 bit and will generate an error trying to load
+the module. Fortunately the default sshd installation comes with both 32 and 64 bit sshd
+binaries, so you will have to point the default sshd to the 32 bit binary:
+    /opt/ssh/sbin/sshd -> /opt/ssh/hpux32/sbin/sshd
+
+When building for HP-UX use the -DHPUX macro with the configure script:
+    $ CFLAGS="-DHPUX" LDFLAGS="-L/usr/local/lib/hpux32/" ./configure \
+            --with-pammoddir=/usr/lib/security/hpux32 --mandir=/usr/share/man --sysconfdir=/etc 
+
+SSL/TLS
+=======
+So far SSL/TLS is not working so do not use ldaps in the URI otherwise the module will get 
+ignored and access allowed.
+
+Configuration
+=============
+You need to configure the module itself, then include the module in the
+PAM stack. Please see the pam_hbac.conf(5) man page for the available
+configuration options.
+
+This has only been tested with the sshd service.
+When the config file is created, put the following into /etc/pam.conf:
+    sshd     account required       pam_hbac.so ignore_unknown_user ignore_authinfo_unavail
+
+Adding the option `ignore_unknown_user` is important on FreeBSD for the same
+reason Linux systems normally use `pam_localuser.so` - pam_hbac looks up
+accounts using NSS calls and a failure to look up a user would deny access,
+because no rules would apply. Additionally, pam_hbac returns PAM_UNKNOWN_USER
+for root, which might e impractical if you decide to put the module into
+the system-wide configuration.
+
+Similarly, adding the `ignore_authinfo_unavail` option is handy in case
+the LDAP server is not reachable. In that case, pam_hbac would return
+PAM_IGNORE and proceed with the rest of the stack instead of a hard error.
+
+Before making any changes to the PAM stack, please make sure to have a root
+console open until you finish testing of pam_hbac setup, to make sure you
+don't lock yourself out of the system!

--- a/doc/README.HPUX
+++ b/doc/README.HPUX
@@ -46,7 +46,7 @@ This has only been tested with the sshd service.
 When the config file is created, put the following into /etc/pam.conf:
     sshd     account required       pam_hbac.so ignore_unknown_user ignore_authinfo_unavail
 
-Adding the option `ignore_unknown_user` is important on FreeBSD for the same
+Adding the option `ignore_unknown_user` is important on HP-UX for the same
 reason Linux systems normally use `pam_localuser.so` - pam_hbac looks up
 accounts using NSS calls and a failure to look up a user would deny access,
 because no rules would apply. Additionally, pam_hbac returns PAM_UNKNOWN_USER

--- a/doc/README.Solaris
+++ b/doc/README.Solaris
@@ -67,7 +67,7 @@ When the config file is created, put the following into /etc/pam.d/other
 or just the particular PAM service you would like to control access to:
     account    required    pam_hbac.so    ignore_unknown_user ignore_authinfo_unavail
 
-Adding the option `ignore_unknown_user` is important on FreeBSD for the same
+Adding the option `ignore_unknown_user` is important on Solaris for the same
 reason Linux systems normally use `pam_localuser.so` - pam_hbac looks up
 accounts using NSS calls and a failure to look up a user would deny access,
 because no rules would apply. Additionally, pam_hbac returns PAM_UNKNOWN_USER

--- a/src/pam_hbac_config.c
+++ b/src/pam_hbac_config.c
@@ -281,13 +281,20 @@ ph_read_config(pam_handle_t *pamh,
 
     logger(pamh, LOG_DEBUG, "config file: %s", config_file);
 
+#ifdef HPUX
+    errno = 666;       // for some reason when invoked through pam in HPUX, fopen doesn't set errno on error
+#else
     errno = 0;
+#endif
+
     fp = fopen(config_file, "r");
+
     if (fp == NULL) {
         /* According to PAM Documentation, such an error in a config file
          * SHOULD be logged at LOG_ALERT level
          */
         ret = errno;
+
         logger(pamh, LOG_ALERT,
                "pam_hbac: cannot open config file %s [%d]: %s\n",
                config_file, ret, strerror(ret));

--- a/src/pam_hbac_config.c
+++ b/src/pam_hbac_config.c
@@ -281,14 +281,12 @@ ph_read_config(pam_handle_t *pamh,
 
     logger(pamh, LOG_DEBUG, "config file: %s", config_file);
 
+/* for some reason when invoked through pam in HPUX, fopen doesn't set errno on error */
 #ifdef HPUX
-    errno = 666;       // for some reason when invoked through pam in HPUX, fopen doesn't set errno on error
-#else
-    errno = 0;
+    errno = EIO;
 #endif
 
     fp = fopen(config_file, "r");
-
     if (fp == NULL) {
         /* According to PAM Documentation, such an error in a config file
          * SHOULD be logged at LOG_ALERT level

--- a/src/pam_hbac_ldap.c
+++ b/src/pam_hbac_ldap.c
@@ -402,7 +402,6 @@ start_tls(pam_handle_t *ph, LDAP *ldap, const char *ca_cert, bool secure)
     logger(ph, LOG_DEBUG,
            "START TLS result: %s(%d), %s\n",
            ldap_err2string(ldaperr), ldaperr, errmsg);
-
     if (ldap_tls_inplace(ldap)) {
         logger(ph, LOG_DEBUG, "SSL/TLS handler already in place.\n");
         lret = LDAP_SUCCESS;
@@ -509,6 +508,11 @@ static int secure_connection(pam_handle_t *ph,
                              const char *ca_cert,
                              bool secure)
 {
+#if defined(HPUX)
+#undef HAVE_LDAP_START_TLS                      # couldn't get it to work on hpux
+#undef HAVE_LDAPSSL_CLIENT_INIT 
+#endif
+
 #if defined(HAVE_LDAP_START_TLS)
     return start_tls(ph, ldap, ca_cert, secure);
 #elif defined(HAVE_LDAPSSL_CLIENT_INIT)

--- a/src/pam_hbac_ldap.c
+++ b/src/pam_hbac_ldap.c
@@ -508,8 +508,9 @@ static int secure_connection(pam_handle_t *ph,
                              const char *ca_cert,
                              bool secure)
 {
+/* couldn't get it to work on hpux */
 #if defined(HPUX)
-#undef HAVE_LDAP_START_TLS                      # couldn't get it to work on hpux
+#undef HAVE_LDAP_START_TLS
 #undef HAVE_LDAPSSL_CLIENT_INIT 
 #endif
 

--- a/src/pam_hbac_obj.h
+++ b/src/pam_hbac_obj.h
@@ -40,6 +40,11 @@ int ph_get_svc(struct pam_hbac_ctx *ctx,
                const char *svcname,
                struct ph_entry **_svc);
 
+static int ph_getgrouplist_fallback(const char *name,
+                             gid_t primary_gid,
+                             gid_t *groups,
+                             int *ngroups_ptr);
+
 /* pam_hbac_eval_req.c */
 
 int ph_create_hbac_eval_req(struct ph_user *user,

--- a/src/pam_hbac_utils.c
+++ b/src/pam_hbac_utils.c
@@ -129,5 +129,13 @@ void va_logger(pam_handle_t *pamh, int level, const char *fmt, va_list ap)
     va_end(apd);
 #endif
 
+#ifdef vsyslog
     pam_vsyslog(pamh, LOG_AUTHPRIV|level, fmt, ap);
+#else              // tried to make it generic in case vsyslog doesn't exist, tested on hpux only
+    char *params = malloc(sizeof(char) * 1024);
+    vsnprintf(params, 1024, fmt , ap);
+    syslog(LOG_AUTHPRIV|level, params, NULL);
+    free(params);
+#endif
+
 }

--- a/src/pam_hbac_utils.c
+++ b/src/pam_hbac_utils.c
@@ -131,7 +131,8 @@ void va_logger(pam_handle_t *pamh, int level, const char *fmt, va_list ap)
 
 #ifdef vsyslog
     pam_vsyslog(pamh, LOG_AUTHPRIV|level, fmt, ap);
-#else              // tried to make it generic in case vsyslog doesn't exist, tested on hpux only
+#else
+    /* tried to make it generic in case vsyslog doesn't exist, tested on hpux only */
     char *params = malloc(sizeof(char) * 1024);
     vsnprintf(params, 1024, fmt , ap);
     syslog(LOG_AUTHPRIV|level, params, NULL);


### PR DESCRIPTION
As a disclaimer I'm not a developer so this might not be the best approach.

Tried not to make big changes to the existing code by adding as much as possible the code for HPUX in else statments.
Since SSL/TLS is not working (yet) had to resort to the 'HPUX' macro to undefine 'HAVE_LDAP_START_TLS' and 'HAVE_LDAPSSL_CLIENT_INIT' to return 'LDAP_NOT_SUPPORTED' in the secure_connection function.
Had to write code to substitute the 'pam_vsyslog' function that doesn't exist (the 'pam_syslog' function isn't an option since it doesn't take a va_list argument).
Had to write code to implement get-groups-for-user since the 'getgrgid_r' function doesn't exist.
Strangely, when invoked through pam in HPUX, 'fopen' doesn't set 'errno' on error. Changed the initialization value of the 'errno' variable to an unknown value (666) so that in case there's an error trying to open it, an error is returned instead of the value 0 that would be considered as if no error had occurred.

Haven't had the chance to compile it in Solaris or Linux to make sure that the functionality on those platforms has not been affected.

I'm available for further tests and of course suggestions on the implementation part.
