### PR TITLE
obj: Continue if get_user_names() can't translate a GID into a group name

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -307,6 +307,7 @@ obj_tests_CFLAGS = \
 	$(NULL)
 obj_tests_LDFLAGS = \
 	-Wl,-wrap,ph_search \
+	-Wl,-wrap,getgrgid_r \
 	$(NULL)
 obj_tests_LDADD = \
 	$(OPENLDAP_LIBS) \

--- a/src/pam_hbac_obj.c
+++ b/src/pam_hbac_obj.c
@@ -124,8 +124,9 @@ get_user_names(struct passwd *pwd,
                gid_t *gidlist,
                size_t ngroups)
 {
-    struct ph_user *user;
-    size_t i;
+    struct ph_user *user = NULL;
+    size_t gid_i = 0;
+    size_t name_i = 0;
 
     user = malloc(sizeof(struct ph_user));
     if (user == NULL) {
@@ -144,12 +145,12 @@ get_user_names(struct passwd *pwd,
         return NULL;
     }
 
-    for (i = 0; i < ngroups; i++) {
-        user->group_names[i] = getgroupname(gidlist[i]);
-        if (user->group_names[i] == NULL) {
-            ph_free_user(user);
-            return NULL;
+    for (gid_i = 0; gid_i < ngroups; gid_i++) {
+        user->group_names[name_i] = getgroupname(gidlist[gid_i]);
+        if (user->group_names[name_i] == NULL) {
+            continue;
         }
+        name_i++;
     }
 
     return user;


### PR DESCRIPTION
This is safe because only ALLOW rules are available, so at worst, the
user would be denied legitimate access (which he would be anyway,
because the whole session would error out previously)