### PR TITLE
obj: Be more defensive about an empty host name

### DIFF
--- a/src/pam_hbac_obj.c
+++ b/src/pam_hbac_obj.c
@@ -314,6 +314,11 @@ ph_get_host(struct pam_hbac_ctx *ctx,
         return EINVAL;
     }
 
+    if (strlen(hostname) == 0) {
+        logger(ctx->pamh, LOG_NOTICE, "Host name is empty\n");
+        return ENOENT;
+    }
+
     ret = asprintf(&host_filter, "%s=%s",
                    ph_host_attrs[PH_MAP_HOST_FQDN], hostname);
     if (ret < 0) {

--- a/src/tests/obj_tests.c
+++ b/src/tests/obj_tests.c
@@ -307,6 +307,21 @@ test_ph_host_no_fqdn(void **state)
 }
 
 static void
+test_ph_host_name_empty(void **state)
+{
+    int ret;
+    struct pam_hbac_ctx ph_ctx;
+    const char *hostname = "";
+    struct ph_entry *host = NULL;
+
+    memset(&ph_ctx, 0, sizeof(ph_ctx));
+
+    ret = ph_get_host(&ph_ctx, hostname, &host);
+    assert_int_equal(ret, ENOENT);
+    assert_null(host);
+}
+
+static void
 test_ph_svc(void **state)
 {
     int ret;
@@ -382,6 +397,7 @@ main(void)
         cmocka_unit_test(test_ph_host_multiple),
         cmocka_unit_test(test_ph_host_srch_fail),
         cmocka_unit_test(test_ph_host_no_fqdn),
+        cmocka_unit_test(test_ph_host_name_empty),
         cmocka_unit_test(test_ph_svc),
         cmocka_unit_test(test_ph_svc_multiple),
         cmocka_unit_test(test_ph_svc_srch_fail),


### PR DESCRIPTION
Resolves:
https://github.com/jhrozek/pam_hbac/issues/84

Gueards against an empty hostname by erroring out before the empty host
name is used in a filter, which would cause a Protocol Error.