### PR TITLE
Fix logger() messages with unqualified host name

### DIFF
--- a/src/pam_hbac_config.c
+++ b/src/pam_hbac_config.c
@@ -117,7 +117,9 @@ warn_unqualified_hostname(pam_handle_t *pamh, const char *hostname)
     char *dot;
 
     if (hostname == NULL) {
-        logger(pamh, LOG_NOTICE, "Hostname %s is not set, make sure HOST_NAME is set\n");
+        logger(pamh, LOG_NOTICE,
+               "Hostname %s is not set, make sure HOST_NAME is set\n",
+               hostname);
         return;
     }
 
@@ -126,7 +128,10 @@ warn_unqualified_hostname(pam_handle_t *pamh, const char *hostname)
         return;
     }
 
-    logger(pamh, LOG_NOTICE, "Hostname %s is not qualified, make sure HOST_NAME is set\n");
+    logger(pamh,
+           LOG_NOTICE,
+           "Hostname %s is not qualified, make sure HOST_NAME is set\n",
+           hostname);
 }
 
 static int


### PR DESCRIPTION
There was an unused format expansion. The logger function really should had been marked with some PRINTF-like attribute.