### PR TITLE
102_ldap24fix - if-else statement fixed for variable/library

### DIFF
--- a/doc/README.Solaris
+++ b/doc/README.Solaris
@@ -14,6 +14,9 @@ the IPA or AD users. For example, for users coming from an AD trust:
 A good starting point for this configuration is to read:
     https://www.freeipa.org/page/ConfiguringUnixClients
 
+When using Domain Resolution Order, it is recommended to be on at least
+SRU 29 (0.175.3.29.0.1.0), otherwise users cannot login.
+
 Building from source
 ====================
 Please make sure all required dependencies are installed. On Solaris 11,

--- a/external/ldap.m4
+++ b/external/ldap.m4
@@ -41,8 +41,9 @@ AC_DEFUN([AM_CHECK_OPENLDAP],
         fi
         if test "$with_ldap_two_four" = "yes" ; then
             OPENLDAP_LIBS="${OPENLDAP_LIBS} -lldap-2.4"
+        else
+            OPENLDAP_LIBS="${OPENLDAP_LIBS} -lldap"
         fi
-        OPENLDAP_LIBS="${OPENLDAP_LIBS} -lldap"
     else
         AC_MSG_ERROR([LDAP libraries not found])
     fi


### PR DESCRIPTION
Compiling on Solaris uses the Sun/Oracle LDAP library which causes segfaults. This if-else fix ensures the ldap 2.4 (openldap) library is actually used for the module.